### PR TITLE
Remove observeOn(AndroidSchedulers.mainThread()) from EpitomeEntryFragme...

### DIFF
--- a/app/src/main/java/com/github/gfx/helium/fragment/EpitomeEntryFragment.java
+++ b/app/src/main/java/com/github/gfx/helium/fragment/EpitomeEntryFragment.java
@@ -122,7 +122,6 @@ public class EpitomeEntryFragment extends Fragment
 
     Observable<?> reload() {
         return AppObservable.bindFragment(this, feedClient.getEntries())
-                .observeOn(AndroidSchedulers.mainThread())
                 .doOnNext(new Action1<List<EpitomeEntry>>() {
                     @Override
                     public void call(List<EpitomeEntry> entries) {

--- a/app/src/main/java/com/github/gfx/helium/fragment/HatebuEntryFragment.java
+++ b/app/src/main/java/com/github/gfx/helium/fragment/HatebuEntryFragment.java
@@ -140,7 +140,6 @@ public class HatebuEntryFragment extends Fragment
             observable = feedClient.getHotentries();
         }
         return AppObservable.bindFragment(this, observable)
-                .observeOn(AndroidSchedulers.mainThread())
                 .doOnNext(new Action1<List<HatebuEntry>>() {
                     @Override
                     public void call(List<HatebuEntry> items) {


### PR DESCRIPTION
...nt and HatebuEntryFragment

https://github.com/ReactiveX/RxAndroid/blob/0.x/rxandroid/src/main/java/rx/android/app/AppObservable.java#L69-87

AppObservable#bindFragment method sets observeOn(mainThread()).
Setting observeOn(AndroidSchedulers.mainThread()) again is redundant.